### PR TITLE
[IDP-3406] Only log in to fusionauth ACR when dependency requested

### DIFF
--- a/src/Leap.Cli/Pipeline/LoginAzureAcrPipelineStep.cs
+++ b/src/Leap.Cli/Pipeline/LoginAzureAcrPipelineStep.cs
@@ -27,12 +27,15 @@ internal sealed class LoginAzureAcrPipelineStep(
             .OfType<string>()
             .ToHashSet(StringComparer.OrdinalIgnoreCase);
 
+        if (state.Dependencies.OfType<FusionAuthDependency>().Any())
+        {
+            acrNames.Add(Constants.FusionAuthProvisioningAcrName);
+        }
+
         foreach (var acrName in acrNames)
         {
             await this.LoginToAzureAcrAsync(acrName, cancellationToken);
         }
-
-        await this.LoginToAzureAcrAsync(Constants.FusionAuthProvisioningAcrName, cancellationToken);
     }
 
     private async Task LoginToAzureAcrAsync(string acrName, CancellationToken cancellationToken)


### PR DESCRIPTION
## Description of changes

Skip fusionauth provisioning ACR login which takes 1-3 seconds at startup when fusionauth is not a requested dependency.

## Additional checks

Manually QA-ed with breakpoints with leap.yaml files with and without the fusionauth dependency.