### PR TITLE
FESD-54 Escape shell arguments on macOS

### DIFF
--- a/src/Leap.Cli/Platform/PlatformHelper.cs
+++ b/src/Leap.Cli/Platform/PlatformHelper.cs
@@ -148,7 +148,7 @@ internal sealed class PlatformHelper(ILogger<PlatformHelper> logger) : IPlatform
 
         foreach (var arg in args)
         {
-            startInfo.ArgumentList.Add(EscapeShellArg(arg));
+            startInfo.ArgumentList.Add(arg);
         }
     }
 
@@ -159,7 +159,7 @@ internal sealed class PlatformHelper(ILogger<PlatformHelper> logger) : IPlatform
 
         foreach (var arg in args)
         {
-            startInfo.ArgumentList.Add(EscapeShellArg(arg));
+            startInfo.ArgumentList.Add(arg);
         }
     }
 


### PR DESCRIPTION
<!-- Please fill out any relevant sections and remove those that don't apply -->

## Description of changes
Escapes shell arguments to fix a command injection in Leap that causes the hosts file update to fail on macOS because the command-line is passed as an argument in a shell from an osascript command.

## Breaking changes
<!-- What breaking changes were added (if any) and how are they addressed? -->

## Additional checks
Running leap on macOS with an unmanaged hosts file:
```
@WL-K3WYFW33WD:~/s/wl-leap-local-dev (hotfix/tgh/fesd-54) ❯ src/Leap.Cli/bin/Debug/net8.0/Workleap.Leap run --file /Users/tristan.g-hane/src/ShareGate.Insights/tools/leap.yaml
Checking for updates...
Attempting to authenticate silently against Azure DevOps using the account tristan.g-hane@workleap.com...
Silent authentication succeeded
===============================================================
Update available: 1.0.0-local -> 1.27.1
Run: dotnet tool update Workleap.Leap --global --interactive --add-source "https://pkgs.dev.azure.com/gsoft/_packaging/gsoft/nuget/v3/index.json" --verbosity minimal --no-cache
===============================================================
NuGet package 'Aspire.Hosting.Orchestration.osx-arm64' with version '9.2.1' is already extracted to the directory '/Users/tristan.g-hane/.leap/generated/nuget-packages/Aspire.Hosting.Orchestration.osx-arm64.9.2.1'.
NuGet package 'Aspire.Dashboard.Sdk.osx-arm64' with version '9.2.1' is already extracted to the directory '/Users/tristan.g-hane/.leap/generated/nuget-packages/Aspire.Dashboard.Sdk.osx-arm64.9.2.1'.
Local development certificate already exists. Use it for HTTPS in your services:
 - Certificate: ~/.leap/generated/certificates/workleap-dev-certificate.crt
 - Private key: ~/.leap/generated/certificates/workleap-dev-certificate.key
Creating a certificate authority bundle for Docker containers at location '/Users/tristan.g-hane/.leap/generated/certificates/workleap-dev-certificate-ca.crt'
Updating hosts file to add the following hostnames: protect-local.sharegate-dev.com, mongo
Please accept to elevate the process to update the hosts file
Starting elevated process 'osascript' with arguments '-e do shell script "/Users/tristan.g-hane/src/wl-leap-local-dev/src/Leap.Cli/bin/Debug/net8.0/Workleap.Leap 'updatehostsfile' 'protect-local.sharegate-dev.com;mongo'" with prompt "Leap" with administrator privileges'

Checking if logged in to Azure CLI...
Environment variables:
 - Services__protectfrontend__BaseUrl: https://protect-local.sharegate-dev.com:1347
 - IDENTITY_ENDPOINT: http://127.0.0.1:6501/token
 - IMDS_ENDPOINT: dummy_required_value
Starting .NET Aspire dashboard...
----------------------------------------------
Dashboard available at https://localhost:18888
----------------------------------------------
Press Ctrl+C to stop Leap
```

The hosts file after running this:
```
@WL-K3WYFW33WD:~/s/wl-leap-local-dev (hotfix/tgh/fesd-54) took 1m0s ❯ cat /etc/hosts      
##
# Host Database
#
# localhost is used to configure the loopback interface
# when the system is booting.  Do not change this entry.
##
127.0.0.1	localhost
255.255.255.255	broadcasthost
::1             localhost
# Begin lines managed by Leap CLI
127.0.0.1 protect-local.sharegate-dev.com
127.0.0.1 mongo
# End lines managed by Leap CLI
```

- [ ] Updated the documentation of the project to reflect the changes
- [ ] Added new tests that cover the code changes