### PR TITLE
Add Cortex deployment tracker

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -55,6 +55,7 @@ jobs:
     uses: workleap/wl-reusable-workflows/.github/workflows/linearb-deployment.yml@main
     with:
       environment: 'release'
+      cortexEntityIdOrTag: service-leap-local-dev
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
Jira issue link: [feng-722](https://workleap.atlassian.net/browse/feng-722)

This pull request includes a small update to the `.github/workflows/publish.yml` file. The change adds a new input parameter, `cortexEntityIdOrTag`, with the value `service-leap-local-dev` to the `linearb-deployment.yml` reusable workflow.