### PR TITLE
FENG-904 - Prevent updates to system.commandline

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -44,6 +44,17 @@
       "matchPackageNames": [
         "/^Microsoft\\.Extensions\\./"
       ]
+    },
+    {
+      "matchManagers": [
+        "nuget"
+      ],
+      "matchPackageNames": [
+        "System.CommandLine",
+        "System.CommandLine.*"
+      ],
+      "allowedVersions": "<= 2.0.0-beta4.22272.1",
+      "description": "Breaking changes are still being introduced, we'll wait for a stable release before updating."
     }
   ]
 }


### PR DESCRIPTION
Jira issue link: [feng-904](https://workleap.atlassian.net/browse/feng-904)

## Description of changes
This pull request updates the `renovate.json` configuration to prevent automatic updates of the `System.CommandLine` NuGet package until a stable release is available. This helps avoid potential issues from breaking changes in pre-release versions.

Dependency management:

* Added a new rule to block Renovate from updating `System.CommandLine` and related packages beyond version `2.0.0-beta4.22272.1`, with a description explaining the rationale.

## Breaking changes
<!-- What breaking changes were added (if any) and how are they addressed? -->

## Additional checks
<!-- Please check what applies. Note that some of these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Updated the documentation of the project to reflect the changes
- [ ] Added new tests that cover the code changes