### PR TITLE
[SGD-19370] chore: update package project URL

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -3,7 +3,7 @@
     <Copyright>Copyright © Workleap $([System.DateTime]::UtcNow.ToString(yyyy))</Copyright>
     <Authors>Workleap</Authors>
     <Owners>Workleap</Owners>
-    <PackageProjectUrl>https://dev.azure.com/gsoft/Shared-Assets/_git/Leap</PackageProjectUrl>
+    <PackageProjectUrl>https://github.com/workleap/wl-leap-local-dev</PackageProjectUrl>
     <LangVersion>13</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>


### PR DESCRIPTION
Jira issue link: [SGD-19370](https://workleap.atlassian.net/browse/SGD-19370)

Updated the `PackageSourceUrl` in order to fix broken links in PRs raised by Renovate involving this dependency.

[SGD-19370]: https://workleap.atlassian.net/browse/SGD-19370?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ