### PR TITLE
Feature/sgpd 3823 support custom postgre images

### DIFF
--- a/src/Leap.Cli/Dependencies/PostgresDependencyHandler.cs
+++ b/src/Leap.Cli/Dependencies/PostgresDependencyHandler.cs
@@ -21,10 +21,10 @@ internal sealed class PostgresDependencyHandler(
     private const string ServiceName = PostgresDependencyYaml.YamlDiscriminator;
     private const string ContainerName = "leap-postgres";
     private const string VolumeName = "leap_postgres_data";
+    private const string DefaultComposeImageName = "postgres:17.6-alpine";
 
     private static readonly string HostConnectionString = $"postgresql://127.0.0.1:{HostPostgresPort}/postgres?user=postgres&password=localpassword";
     private static readonly string ContainerConnectionString = $"postgresql://host.docker.internal:{ContainerPostgresPort}/postgres?user=postgres&password=localpassword";
-    private static readonly DockerComposeImageName DefaultComposeImageName = new("postgres:17.6-alpine");
 
     protected override Task HandleAsync(PostgresDependency dependency, CancellationToken cancellationToken)
     {
@@ -42,7 +42,7 @@ internal sealed class PostgresDependencyHandler(
         return Task.CompletedTask;
     }
 
-    private static void ConfigureDockerCompose(DockerComposeYaml dockerComposeYaml, DockerComposeImageName imageName)
+    private static void ConfigureDockerCompose(DockerComposeYaml dockerComposeYaml, string imageName)
     {
         const string dbName = "postgres";
         const string pgUser = "postgres";
@@ -50,7 +50,7 @@ internal sealed class PostgresDependencyHandler(
 
         var service = new DockerComposeServiceYaml
         {
-            Image = imageName,
+            Image = new DockerComposeImageName(imageName),
             ContainerName = ContainerName,
             Restart = DockerComposeConstants.Restart.UnlessStopped,
             Environment = new KeyValueCollectionYaml

--- a/src/Leap.Cli/Dependencies/PostgresDependencyHandler.cs
+++ b/src/Leap.Cli/Dependencies/PostgresDependencyHandler.cs
@@ -1,4 +1,4 @@
-﻿using System.Text.Json.Nodes;
+using System.Text.Json.Nodes;
 using Leap.Cli.Aspire;
 using Leap.Cli.DockerCompose;
 using Leap.Cli.DockerCompose.Yaml;
@@ -24,11 +24,12 @@ internal sealed class PostgresDependencyHandler(
 
     private static readonly string HostConnectionString = $"postgresql://127.0.0.1:{HostPostgresPort}/postgres?user=postgres&password=localpassword";
     private static readonly string ContainerConnectionString = $"postgresql://host.docker.internal:{ContainerPostgresPort}/postgres?user=postgres&password=localpassword";
+    private static readonly DockerComposeImageName DefaultComposeImageName = new("postgres:17.6-alpine");
 
     protected override Task HandleAsync(PostgresDependency dependency, CancellationToken cancellationToken)
     {
         TelemetryMeters.TrackPostgresStart();
-        ConfigureDockerCompose(dockerCompose.Configuration);
+        ConfigureDockerCompose(dockerCompose.Configuration, dependency.ImageName ?? DefaultComposeImageName);
         environmentVariables.Configure(ConfigureEnvironmentVariables);
         ConfigureAppSettingsJson(appSettingsJson.Configuration);
 
@@ -41,7 +42,7 @@ internal sealed class PostgresDependencyHandler(
         return Task.CompletedTask;
     }
 
-    private static void ConfigureDockerCompose(DockerComposeYaml dockerComposeYaml)
+    private static void ConfigureDockerCompose(DockerComposeYaml dockerComposeYaml, DockerComposeImageName imageName)
     {
         const string dbName = "postgres";
         const string pgUser = "postgres";
@@ -49,7 +50,7 @@ internal sealed class PostgresDependencyHandler(
 
         var service = new DockerComposeServiceYaml
         {
-            Image = new DockerComposeImageName("postgres:17.6-alpine"),
+            Image = imageName,
             ContainerName = ContainerName,
             Restart = DockerComposeConstants.Restart.UnlessStopped,
             Environment = new KeyValueCollectionYaml

--- a/src/Leap.Cli/Dependencies/PostgresDependencyYaml.cs
+++ b/src/Leap.Cli/Dependencies/PostgresDependencyYaml.cs
@@ -7,6 +7,6 @@ internal sealed class PostgresDependencyYaml : DependencyYaml
 {
     public const string YamlDiscriminator = "postgres";
 
-    [YamlMember(Alias = "imagename", DefaultValuesHandling = DefaultValuesHandling.OmitEmptyCollections)]
+    [YamlMember(Alias = "imagename", DefaultValuesHandling = DefaultValuesHandling.OmitNull)]
     public string? ImageName { get; set; }
 }

--- a/src/Leap.Cli/Dependencies/PostgresDependencyYaml.cs
+++ b/src/Leap.Cli/Dependencies/PostgresDependencyYaml.cs
@@ -1,8 +1,12 @@
-﻿using Leap.Cli.Configuration.Yaml;
+using Leap.Cli.Configuration.Yaml;
+using YamlDotNet.Serialization;
 
 namespace Leap.Cli.Dependencies;
 
 internal sealed class PostgresDependencyYaml : DependencyYaml
 {
     public const string YamlDiscriminator = "postgres";
+
+    [YamlMember(Alias = "imagename", DefaultValuesHandling = DefaultValuesHandling.OmitEmptyCollections)]
+    public string? ImageName { get; set; }
 }

--- a/src/Leap.Cli/Dependencies/PostgresDependencyYaml.cs
+++ b/src/Leap.Cli/Dependencies/PostgresDependencyYaml.cs
@@ -7,6 +7,6 @@ internal sealed class PostgresDependencyYaml : DependencyYaml
 {
     public const string YamlDiscriminator = "postgres";
 
-    [YamlMember(Alias = "imagename", DefaultValuesHandling = DefaultValuesHandling.OmitNull)]
-    public string? ImageName { get; set; }
+    [YamlMember(Alias = "imagetag", DefaultValuesHandling = DefaultValuesHandling.OmitNull)]
+    public string? ImageTag { get; set; }
 }

--- a/src/Leap.Cli/Dependencies/PostgresDependencyYamlHandler.cs
+++ b/src/Leap.Cli/Dependencies/PostgresDependencyYamlHandler.cs
@@ -8,7 +8,7 @@ internal sealed class PostgresDependencyYamlHandler : IDependencyYamlHandler<Pos
     {
         return new PostgresDependencyYaml
         {
-            ImageName = leftYaml.ImageName ?? rightYaml.ImageName,
+            ImageTag = leftYaml.ImageTag ?? rightYaml.ImageTag,
         };
     }
 
@@ -16,7 +16,7 @@ internal sealed class PostgresDependencyYamlHandler : IDependencyYamlHandler<Pos
     {
         return new PostgresDependency
         {
-            ImageName = yaml.ImageName
+            ImageTag = yaml.ImageTag
         };
     }
 }

--- a/src/Leap.Cli/Dependencies/PostgresDependencyYamlHandler.cs
+++ b/src/Leap.Cli/Dependencies/PostgresDependencyYamlHandler.cs
@@ -1,4 +1,5 @@
-﻿using Leap.Cli.Model;
+using Leap.Cli.DockerCompose.Yaml;
+using Leap.Cli.Model;
 
 namespace Leap.Cli.Dependencies;
 
@@ -11,6 +12,7 @@ internal sealed class PostgresDependencyYamlHandler : IDependencyYamlHandler<Pos
 
     public Dependency ToDependencyModel(PostgresDependencyYaml yaml)
     {
-        return new PostgresDependency();
+        var imageName = yaml.ImageName is not null ? new DockerComposeImageName(yaml.ImageName) : null;
+        return new PostgresDependency(imageName);
     }
 }

--- a/src/Leap.Cli/Dependencies/PostgresDependencyYamlHandler.cs
+++ b/src/Leap.Cli/Dependencies/PostgresDependencyYamlHandler.cs
@@ -1,4 +1,3 @@
-using Leap.Cli.DockerCompose.Yaml;
 using Leap.Cli.Model;
 
 namespace Leap.Cli.Dependencies;
@@ -7,12 +6,17 @@ internal sealed class PostgresDependencyYamlHandler : IDependencyYamlHandler<Pos
 {
     public PostgresDependencyYaml Merge(PostgresDependencyYaml leftYaml, PostgresDependencyYaml rightYaml)
     {
-        return leftYaml;
+        return new PostgresDependencyYaml
+        {
+            ImageName = leftYaml.ImageName ?? rightYaml.ImageName,
+        };
     }
 
     public Dependency ToDependencyModel(PostgresDependencyYaml yaml)
     {
-        var imageName = yaml.ImageName is not null ? new DockerComposeImageName(yaml.ImageName) : null;
-        return new PostgresDependency(imageName);
+        return new PostgresDependency
+        {
+            ImageName = yaml.ImageName
+        };
     }
 }

--- a/src/Leap.Cli/Model/PostgresDependency.cs
+++ b/src/Leap.Cli/Model/PostgresDependency.cs
@@ -1,9 +1,8 @@
 using Leap.Cli.Dependencies;
-using Leap.Cli.DockerCompose.Yaml;
 
 namespace Leap.Cli.Model;
 
-internal sealed class PostgresDependency(DockerComposeImageName? imageName) : Dependency(PostgresDependencyYaml.YamlDiscriminator)
+internal sealed class PostgresDependency() : Dependency(PostgresDependencyYaml.YamlDiscriminator)
 {
-    public DockerComposeImageName? ImageName { get; } = imageName;
+    public string? ImageName { get; init; }
 }

--- a/src/Leap.Cli/Model/PostgresDependency.cs
+++ b/src/Leap.Cli/Model/PostgresDependency.cs
@@ -4,5 +4,5 @@ namespace Leap.Cli.Model;
 
 internal sealed class PostgresDependency() : Dependency(PostgresDependencyYaml.YamlDiscriminator)
 {
-    public string? ImageName { get; init; }
+    public string? ImageTag { get; init; }
 }

--- a/src/Leap.Cli/Model/PostgresDependency.cs
+++ b/src/Leap.Cli/Model/PostgresDependency.cs
@@ -1,5 +1,9 @@
-﻿using Leap.Cli.Dependencies;
+using Leap.Cli.Dependencies;
+using Leap.Cli.DockerCompose.Yaml;
 
 namespace Leap.Cli.Model;
 
-internal sealed class PostgresDependency() : Dependency(PostgresDependencyYaml.YamlDiscriminator);
+internal sealed class PostgresDependency(DockerComposeImageName? imageName) : Dependency(PostgresDependencyYaml.YamlDiscriminator)
+{
+    public DockerComposeImageName? ImageName { get; } = imageName;
+}


### PR DESCRIPTION
Jira issue link: [SGPD-3823](https://workleap.atlassian.net/browse/SGPD-3823)

## Description of changes
Introduces support for choosing the Postgres image when specifying the dependency via the `imageName` parameter.

This is helpful since version 17 (which is the default and kept up to date) has only recently (July 2025) been made available in Azure, and as of now azurerm is not updated with this so TF scripts cannot install Postgres v17, they are limited to v16. Allowing to run the same version locally as the one that will end up being in production might save some trouble in the long run.

## Breaking changes
The Leap config file is retro compatible, if the new parameter is not present the fallback is the default up to date version.

[SGPD-3823]: https://workleap.atlassian.net/browse/SGPD-3823?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ