### PR TITLE
Changing the connection string format for postgres

### DIFF
--- a/src/Leap.Cli/Dependencies/PostgresDependencyHandler.cs
+++ b/src/Leap.Cli/Dependencies/PostgresDependencyHandler.cs
@@ -22,8 +22,8 @@ internal sealed class PostgresDependencyHandler(
     private const string ContainerName = "leap-postgres";
     private const string VolumeName = "leap_postgres_data";
 
-    private static readonly string HostConnectionString = $"postgresql://127.0.0.1:{HostPostgresPort}/postgres?user=postgres&password=localpassword";
-    private static readonly string ContainerConnectionString = $"postgresql://host.docker.internal:{ContainerPostgresPort}/postgres?user=postgres&password=localpassword";
+    private static readonly string HostConnectionString = $"Host=localhost;Port={HostPostgresPort};Database=postgres;Username=postgres;Password=localpassword";
+    private static readonly string ContainerConnectionString = $"Host=host.docker.internal;Port={ContainerPostgresPort};Database=postgres;Username=postgres;Password=localpassword";
 
     protected override Task HandleAsync(PostgresDependency dependency, CancellationToken cancellationToken)
     {


### PR DESCRIPTION
## Description of changes
Changing the format of the Postgres dependency connection string. The previous format was apparently untested, and did not work properly with EF Core.

## Breaking changes
If someone was using the previous Postgres dependency with the connection string, it may break now.
