### PR TITLE
COMP-6930 Allow *.workleap-stg.com as a local ingress domain

### DIFF
--- a/src/Leap.Cli.Tests/PopulateServicesFromYamlPipelineStepTests.cs
+++ b/src/Leap.Cli.Tests/PopulateServicesFromYamlPipelineStepTests.cs
@@ -26,6 +26,7 @@ public class PopulateServicesFromYamlPipelineStepTests
     [InlineData("a.workleap.com")]
     [InlineData("a.officevibe-dev.com")]
     [InlineData("a.workleap-dev.com")]
+    [InlineData("a.workleap-stg.com")]
     [InlineData("a.workleap-local.com")]
     public void Valid_Localhost_Subdomain_Matches_Wildcard_Localhost_Domains_Regex(string host)
     {

--- a/src/Shared/Constants.cs
+++ b/src/Shared/Constants.cs
@@ -51,6 +51,8 @@ internal static class Constants
         "*.workleap.com",
         "*.officevibe-dev.com",
         "*.workleap-dev.com",
+        // Staging, so local frontends can do hybrid local/cloud cookie-based authentication
+        "*.workleap-stg.com",
         "*.workleap-local.com",
 
         // ShareGate recently adopted a centralized cookie like Officevibe and Workleap, so we need to allow these domains as well


### PR DESCRIPTION
Jira: [COMP-6930](https://workleap.atlassian.net/browse/COMP-6930)

## What

Adds `*.workleap-stg.com` to `SupportedWildcardLocalhostDomainNames` (`src/Shared/Constants.cs`) so Leap can serve local services under the staging parent domain (e.g. `local-compensation.workleap-stg.com`).

## Why

Lets local frontends do hybrid local/cloud **cookie-based authentication against the staging platform** — the same rationale already documented for the `*-dev.com` / `*-local.com` / `*.workleap.com` entries just above it. Because Workleap auth cookies are scoped to the environment's parent domain, a locally-served app must live under `workleap-stg.com` for staging login to work. Today Leap rejects it with *"A service '…' has an invalid host '…workleap-stg.com'. Host must match one of the supported wildcard domains …"*.

## How it works

`SupportedWildcardLocalhostDomainNames` is the single source that drives:

- ingress host validation (`PopulateServicesFromYamlPipelineStep`),
- the mkcert certificate SAN list (`MkcertSupportedDomainNames` — the local cert auto-regenerates to cover the new domain),
- the `/etc/hosts` entries (`UpdateHostsFilePipelineStep`).

So this one entry is the complete change — no other code paths need touching.

## Testing

- Added a matching regex test case: `[InlineData("a.workleap-stg.com")]` in `PopulateServicesFromYamlPipelineStepTests`.
- Existing valid/invalid host tests are unaffected.

## For reviewers

- Consistent with the existing demand-driven pattern (each `*.com` domain was added when a product needed local cookie-auth against it).
- **Platform-side dependency:** for end-to-end login to actually work, the staging platform's auth/CORS + redirect allow-list must also accept the `*.workleap-stg.com` local origin (as the dev environment already does). Flagging in case a corresponding platform-side change is needed — happy to follow up.

## Note on failing checks

The failing `leap-build-and-test` / `leap-system-test` jobs are **unrelated to this change**. They fail on `NU1901` — a NuGet audit advisory for `NuGet.Protocol 7.3.0` (published 2026-07-20) that the build treats as an error. This dependency is on `main`, so the failure reproduces on `main` and every open PR right now. It needs a separate dependency bump / audit-config fix; this branch changes no build config or dependencies.


[COMP-6930]: https://workleap.atlassian.net/browse/COMP-6930?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ