### PR TITLE
Bump NuGet.Protocol 7.3.0 -> 7.3.1 (fix NU1901 blocking builds & 1.32.1 publish)

### DIFF
--- a/src/Leap.Cli/Leap.Cli.csproj
+++ b/src/Leap.Cli/Leap.Cli.csproj
@@ -53,7 +53,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.5" />
     <PackageReference Include="Microsoft.Identity.Client" Version="4.83.1" />
     <PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" Version="4.83.1" />
-    <PackageReference Include="NuGet.Protocol" Version="7.3.0" />
+    <PackageReference Include="NuGet.Protocol" Version="7.3.1" />
     <PackageReference Include="OpenTelemetry" Version="1.15.0" />
     <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.15.0" />
     <PackageReference Include="Spectre.Console" Version="0.54.0" />


### PR DESCRIPTION
Jira issue link: [COMP-6930](https://workleap.atlassian.net/browse/COMP-6930)

Jira: [COMP-6930](https://workleap.atlassian.net/browse/COMP-6930)

## Problem

Every build in the repo is currently failing on `NU1901`: `NuGet.Protocol 7.3.0` is flagged by advisory [GHSA-g4vj-cjjj-v7hg](https://github.com/advisories/GHSA-g4vj-cjjj-v7hg) (published 2026-07-20), and the build treats the NuGet audit finding as an error.

This breaks `main`, every open PR, and — notably — the **`1.32.1` publish** ([failed run](https://github.com/workleap/wl-leap-local-dev/actions/runs/29756063174)), so the released version never reached the feed (`dotnet tool update` still resolves `1.32.0`).

## Fix

Bump the direct `NuGet.Protocol` reference in `src/Leap.Cli/Leap.Cli.csproj` from `7.3.0` → `7.3.1`. Per the advisory, `7.3.1` is the patched release for exactly `7.3.0` — an API-compatible patch bump — so this clears the finding without suppressing the audit (no `NoWarn` / `NuGetAudit` change needed).

## Follow-up

After merge, the **`1.32.1` publish needs to be re-run** (or a new patch cut) so the fixed package reaches the feed.

[COMP-6930]: https://workleap.atlassian.net/browse/COMP-6930?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
