### PR TITLE
Bump NuGet.Protocol to 7.3.1 to clear NU1901 advisory (GHSA-g4vj-cjjj-v7hg)

### DIFF
--- a/src/Leap.Cli/Leap.Cli.csproj
+++ b/src/Leap.Cli/Leap.Cli.csproj
@@ -53,7 +53,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.5" />
     <PackageReference Include="Microsoft.Identity.Client" Version="4.83.1" />
     <PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" Version="4.83.1" />
-    <PackageReference Include="NuGet.Protocol" Version="7.3.0" />
+    <PackageReference Include="NuGet.Protocol" Version="7.3.1" />
     <PackageReference Include="OpenTelemetry" Version="1.15.0" />
     <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.15.0" />
     <PackageReference Include="Spectre.Console" Version="0.54.0" />


### PR DESCRIPTION
## What
Bump `NuGet.Protocol` from `7.3.0` to `7.3.1` in `src/Leap.Cli/Leap.Cli.csproj`.

## Why
Advisory GHSA-g4vj-cjjj-v7hg (published 2026-07-20) flags NuGet.Protocol 7.3.0 (low severity). The build treats the resulting NU1901 audit warning as an error, so the CI `Build` step fails on every branch. This is what broke [PR #121](https://github.com/workleap/wl-leap-local-dev/pull/121)'s pipeline, not that PR's own changes. 7.3.1 is the first patched version.

## Verification
`dotnet build -c Release` on Leap.Cli now completes with 0 warnings, 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)