### PR TITLE
[TEST] Dry-run renovate-pr-autofix workflow against #119 (do not merge)

### DIFF
--- a/.github/workflows/test-renovate-pr-autofix.yml
+++ b/.github/workflows/test-renovate-pr-autofix.yml
@@ -1,13 +1,6 @@
-# TEMPORARY TEST HARNESS — validates workleap/wl-github-actions PR #1164
-# (the new renovate-pr-autofix reusable workflow) against a real failing
-# Renovate PR (#119) before that PR is merged to wl-github-actions' main.
-#
-# Not meant to be merged: close this PR once the test run has been reviewed.
-# Targets PR #119 explicitly (pr-number below), regardless of which PR this
-# test workflow itself is attached to.
-#
-# References the wl-github-actions branch directly (not @main/@latest) since
-# the reusable workflow doesn't exist on main yet.
+# DIAGNOSTIC ONLY — temporarily points at an existing @main reusable workflow
+# to isolate whether wl-leap-local-dev can call ANY wl-github-actions reusable
+# workflow, vs. this being specific to referencing an unmerged branch ref.
 
 name: "[TEST] Renovate PR Auto-Fix dry-run"
 
@@ -24,7 +17,7 @@ permissions:
 
 jobs:
   autofix:
-    uses: workleap/wl-github-actions/.github/workflows/renovate-pr-autofix.yml@add-renovate-pr-autofix-reusable-workflow
+    uses: workleap/wl-github-actions/.github/workflows/dotnet-build.yml@main
     secrets: inherit
     with:
-      pr-number: "119"
+      build-projects: "nonexistent.sln"

--- a/.github/workflows/test-renovate-pr-autofix.yml
+++ b/.github/workflows/test-renovate-pr-autofix.yml
@@ -1,0 +1,30 @@
+# TEMPORARY TEST HARNESS — validates workleap/wl-github-actions PR #1164
+# (the new renovate-pr-autofix reusable workflow) against a real failing
+# Renovate PR (#119) before that PR is merged to wl-github-actions' main.
+#
+# Not meant to be merged: close this PR once the test run has been reviewed.
+# Targets PR #119 explicitly (pr-number below), regardless of which PR this
+# test workflow itself is attached to.
+#
+# References the wl-github-actions branch directly (not @main/@latest) since
+# the reusable workflow doesn't exist on main yet.
+
+name: "[TEST] Renovate PR Auto-Fix dry-run"
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+  pull-requests: read
+  actions: read
+
+jobs:
+  autofix:
+    uses: workleap/wl-github-actions/.github/workflows/renovate-pr-autofix.yml@add-renovate-pr-autofix-reusable-workflow
+    secrets: inherit
+    with:
+      pr-number: "119"


### PR DESCRIPTION
## Purpose

**Temporary test harness — not meant to be merged.** Validates [workleap/wl-github-actions#1164](https://github.com/workleap/wl-github-actions/pull/1164) (a new reusable `renovate-pr-autofix.yml` workflow) against a real failing Renovate PR before that PR merges to `wl-github-actions`' `main`.

Adds `.github/workflows/test-renovate-pr-autofix.yml`, which calls the reusable workflow directly from its unmerged branch (`workleap/wl-github-actions/.github/workflows/renovate-pr-autofix.yml@add-renovate-pr-autofix-reusable-workflow`) and points it at **#119** (`chore(deps): update dependency cliwrap to 3.10.2`) via an explicit `pr-number: "119"` — regardless of this PR's own number.

## What happens

Opening this PR fires the workflow immediately (`pull_request: [opened, synchronize, reopened]`). It will:
1. Resolve PR #119's branch (`renovate/cliwrap-3.x`).
2. Detect it's a .NET change and set up the SDK.
3. Wait for #119's CI (currently failing — `leap-build-and-test` + `leap-system-test` on ubuntu/macos/windows) and, since it's failing, run Claude Code to fix it and **push a real commit to #119's branch**.
4. Run a second pass if the first one pushed a fix.

`workflow_dispatch` is also enabled here for a manual re-run without a new push.

## Cleanup

Close this PR (do not merge) once the test run has been reviewed. Optionally delete the `test/renovate-pr-autofix-119` branch afterward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
